### PR TITLE
pcre2grep: workaround a common optimization in BSD fseek(stdin)

### DIFF
--- a/src/pcre2grep.c
+++ b/src/pcre2grep.c
@@ -3266,6 +3266,7 @@ FILE *zos_test_file;
 
 if (strcmp(pathname, "-") == 0)
   {
+  if (count_limit >= 0) setbuf(stdin, NULL);
   return pcre2grep(stdin, FR_PLAIN, stdin_name,
     (filenames > FN_DEFAULT || (filenames == FN_DEFAULT && !only_one_at_top))?
       stdin_name : NULL);
@@ -4473,6 +4474,11 @@ no file arguments, search stdin, and then exit. */
 
 if (file_lists == NULL && i >= argc)
   {
+  /* Using a buffered stdin, that then is seek is not portable,
+     so attempt to remove the buffer, to workaround reported issues
+     affecting several BSD and AIX */
+  if (count_limit >= 0)
+    setbuf(stdin, NULL);
   rc = pcre2grep(stdin, FR_PLAIN, stdin_name,
     (filenames > FN_DEFAULT)? stdin_name : NULL);
   goto EXIT;


### PR DESCRIPTION
When BSD's fseek moves the position of a read stream within the
current buffer space, will avoid calling lseek for performance reasons, and therefore will
not update that position in the corresponding file handle, breaking the current implementation for -m (that supports stdin as a shared file)

There is ongoing discussion with NetBSD to change that, but the code has been around this way for decades and is likely to affect other UNIX (ex: AIX has been confirmed affected), so it is better to avoid that.

Fixes: #10