### PR TITLE
perldot: perl compatible matching of "." when using NUL or CR terminated subjects

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -389,6 +389,7 @@ These items are all just one unit long:
 
   OP_END                 end of pattern
   OP_ANY                 match any one character other than newline
+  OP_ANY_NOTNL           match any one character other than '\n' or newline
   OP_ALLANY              match any one character, including newline
   OP_ANYBYTE             match any single code unit, even in UTF-8/16 mode
   OP_SOD                 match start of data: \A
@@ -426,6 +427,9 @@ These items are all just one unit long:
 OP_ASSERT_ACCEPT is used when (*ACCEPT) is encountered within an assertion.
 This ends the assertion, not the entire pattern match. The assertion (?!) is
 always optimized to OP_FAIL.
+
+OP_ANY_NOTNL is used for '.' when PCRE2_NO_DOTNL is set and unless
+PCRE2_DOTALL is also set as explained below.
 
 OP_ALLANY is used for '.' when PCRE2_DOTALL is set. It is also used for \C in
 non-UTF modes and in UTF-32 mode (since one code unit still equals one

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -497,12 +497,13 @@ maximum.
 .SH NEWLINES
 .rs
 .sp
-PCRE2 supports five different conventions for indicating line breaks in
+PCRE2 supports six different conventions for indicating line breaks in
 strings: a single CR (carriage return) character, a single LF (linefeed)
-character, the two-character sequence CRLF, any of the three preceding, or any
-Unicode newline sequence. The Unicode newline sequences are the three just
-mentioned, plus the single characters VT (vertical tab, U+000B), FF (form feed,
-U+000C), NEL (next line, U+0085), LS (line separator, U+2028), and PS
+character, the two-character sequence CRLF, any of the three preceding, any
+Unicode newline sequence, or the NUL character (binary zero).
+The Unicode newline sequences are the three just mentioned, plus the
+single characters VT (vertical tab, U+000B), FF (form feed, U+000C),
+NEL (next line, U+0085), LS (line separator, U+2028), and PS
 (paragraph separator, U+2029).
 .P
 Each of the first three conventions is used by at least one operating system as

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -143,6 +143,7 @@ D   is inspected during pcre2_dfa_match() execution
 #define PCRE2_EXTENDED_MORE       0x01000000u  /* C       */
 #define PCRE2_LITERAL             0x02000000u  /* C       */
 #define PCRE2_MATCH_INVALID_UTF   0x04000000u  /*   J M D */
+#define PCRE2_NO_DOTNL            0x08000000u  /* C       */
 
 /* An additional compile options word is available in the compile context. */
 

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -774,7 +774,7 @@ are allowed. */
    PCRE2_EXTENDED|PCRE2_EXTENDED_MORE|PCRE2_MATCH_UNSET_BACKREF| \
    PCRE2_MULTILINE|PCRE2_NEVER_BACKSLASH_C|PCRE2_NEVER_UCP| \
    PCRE2_NEVER_UTF|PCRE2_NO_AUTO_CAPTURE|PCRE2_NO_AUTO_POSSESS| \
-   PCRE2_NO_DOTSTAR_ANCHOR|PCRE2_UCP|PCRE2_UNGREEDY)
+   PCRE2_NO_DOTSTAR_ANCHOR|PCRE2_UCP|PCRE2_UNGREEDY|PCRE2_NO_DOTNL)
 
 #define PUBLIC_LITERAL_COMPILE_EXTRA_OPTIONS \
    (PCRE2_EXTRA_MATCH_LINE|PCRE2_EXTRA_MATCH_WORD)
@@ -5518,7 +5518,8 @@ for (;; pptr++)
     zerofirstcuflags = firstcuflags;
     zeroreqcu = reqcu;
     zeroreqcuflags = reqcuflags;
-    *code++ = ((options & PCRE2_DOTALL) != 0)? OP_ALLANY: OP_ANY;
+    *code++ = ((options & PCRE2_DOTALL) != 0)? OP_ALLANY :
+	       (options & PCRE2_NO_DOTNL)? OP_ANY_NOTNL : OP_ANY;
     break;
 
 
@@ -7404,7 +7405,8 @@ for (;; pptr++)
       here because it just makes it horribly messy. */
 
       default:
-      if (op_previous >= OP_EODN)   /* Not a character type - internal error */
+      /* FIXME: instead of this exception OP_ANY_NOTNL should be renumbered */
+      if (op_previous >= OP_EODN && op_previous != OP_ANY_NOTNL)   /* Not a character type - internal error */
         {
         *errorcodeptr = ERR10;
         return 0;

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -187,7 +187,8 @@ static const uint8_t coptable[] = {
   0, 0, 0, 0,                    /* SKIP, SKIP_ARG, THEN, THEN_ARG         */
   0, 0,                          /* COMMIT, COMMIT_ARG                     */
   0, 0, 0,                       /* FAIL, ACCEPT, ASSERT_ACCEPT            */
-  0, 0, 0                        /* CLOSE, SKIPZERO, DEFINE                */
+  0, 0, 0,                       /* CLOSE, SKIPZERO, DEFINE                */
+  0                              /* .                                      */
 };
 
 /* This table identifies those opcodes that inspect a character. It is used to
@@ -264,7 +265,8 @@ static const uint8_t poptable[] = {
   0, 0, 0, 0,                    /* SKIP, SKIP_ARG, THEN, THEN_ARG         */
   0, 0,                          /* COMMIT, COMMIT_ARG                     */
   0, 0, 0,                       /* FAIL, ACCEPT, ASSERT_ACCEPT            */
-  0, 0, 0                        /* CLOSE, SKIPZERO, DEFINE                */
+  0, 0, 0,                       /* CLOSE, SKIPZERO, DEFINE                */
+  0                              /* .                                      */
 };
 
 /* These 2 tables allow for compact code for testing for \D, \d, \S, \s, \W,

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -1596,6 +1596,10 @@ enum {
 
   OP_DEFINE,         /* 167 */
 
+  /* This is like OP_ANY but also rejects '\n' for compatibility with perl's . */
+
+  OP_ANY_NOTNL,      /* 168 */
+
   /* This is not an opcode, but is used to check that tables indexed by opcode
   are the correct length, in order to catch updating errors - there have been
   some in the past. */
@@ -1655,7 +1659,8 @@ some cases doesn't actually use these names at all). */
   "*MARK", "*PRUNE", "*PRUNE", "*SKIP", "*SKIP",                  \
   "*THEN", "*THEN", "*COMMIT", "*COMMIT", "*FAIL",                \
   "*ACCEPT", "*ASSERT_ACCEPT",                                    \
-  "Close", "Skip zero", "Define"
+  "Close", "Skip zero", "Define",                                 \
+  "."
 
 
 /* This macro defines the length of fixed length operations in the compiled
@@ -1751,7 +1756,8 @@ in UTF-8 mode. The code that uses this table must know about such things. */
   1, 3,                          /* COMMIT, COMMIT_ARG                     */ \
   1, 1, 1,                       /* FAIL, ACCEPT, ASSERT_ACCEPT            */ \
   1+IMM2_SIZE, 1,                /* CLOSE, SKIPZERO                        */ \
-  1                              /* DEFINE                                 */
+  1,                             /* DEFINE                                 */ \
+  1                              /* .                                      */
 
 /* A magic value for OP_RREF to indicate the "any recursion" condition. */
 

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -465,8 +465,8 @@ PCRE (both APIs) for a long time. */
 
 
 /* PCRE2 is able to support several different kinds of newline (CR, LF, CRLF,
-"any" and "anycrlf" at present). The following macros are used to package up
-testing for newlines. NLBLOCK, PSSTART, and PSEND are defined in the various
+NUL, "any" and "anycrlf" at present). The following macros are used to package
+up testing for newlines. NLBLOCK, PSSTART, and PSEND are defined in the various
 modules to indicate in which datablock the parameters exist, and what the
 start/end of string field names are. */
 

--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -880,6 +880,7 @@ switch(*cc)
   case OP_WHITESPACE:
   case OP_NOT_WORDCHAR:
   case OP_WORDCHAR:
+  case OP_ANY_NOTNL:
   case OP_ANY:
   case OP_ALLANY:
   case OP_NOTPROP:
@@ -1287,6 +1288,7 @@ do
       case OP_WHITESPACE:
       case OP_NOT_WORDCHAR:
       case OP_WORDCHAR:
+      case OP_ANY_NOTNL:
       case OP_ANY:
       case OP_ALLANY:
       case OP_ANYBYTE:
@@ -2042,6 +2044,7 @@ while (cc < ccend)
     case OP_WHITESPACE:
     case OP_NOT_WORDCHAR:
     case OP_WORDCHAR:
+    case OP_ANY_NOTNL:
     case OP_ANY:
     case OP_ALLANY:
     case OP_ANYBYTE:
@@ -5550,6 +5553,7 @@ while (TRUE)
     case OP_NOT_DIGIT:
     case OP_NOT_WHITESPACE:
     case OP_NOT_WORDCHAR:
+    case OP_ANY_NOTNL:
     case OP_ANY:
     case OP_ALLANY:
 #if defined SUPPORT_UNICODE && PCRE2_CODE_UNIT_WIDTH != 32
@@ -8552,10 +8556,13 @@ switch(type)
   add_jump(compiler, backtracks, JUMP(type == OP_WORDCHAR ? SLJIT_ZERO : SLJIT_NOT_ZERO));
   return cc;
 
+  case OP_ANY_NOTNL:
   case OP_ANY:
   if (check_str_ptr)
     detect_partial_match(common, backtracks);
   read_char(common, common->nlmin, common->nlmax, backtracks, READ_CHAR_UPDATE_STR_PTR);
+  if (type == OP_ANY_NOTNL && common->newline != CHAR_NL)
+    add_jump(compiler, backtracks, CMP(SLJIT_EQUAL, TMP1, 0, SLJIT_IMM, CHAR_NL));
   if (common->nltype == NLTYPE_FIXED && common->newline > 255)
     {
     jump[0] = CMP(SLJIT_NOT_EQUAL, TMP1, 0, SLJIT_IMM, (common->newline >> 8) & 0xff);
@@ -11894,6 +11901,7 @@ while (cc < ccend)
     case OP_WHITESPACE:
     case OP_NOT_WORDCHAR:
     case OP_WORDCHAR:
+    case OP_ANY_NOTNL:
     case OP_ANY:
     case OP_ALLANY:
     case OP_ANYBYTE:

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -875,6 +875,12 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
 
 
     /*===================================================================== */
+    /* Match any single character type except '\n'; falls through OP_ALLANY */
+
+    case OP_ANY_NOTNL:
+    if (*Feptr == CHAR_LF) RRETURN(MATCH_NOMATCH);
+    /* Fall through */
+
     /* Match any single character type except newline; have to take care with
     CRLF newlines and partial matching. */
 
@@ -2840,6 +2846,7 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
 #ifdef SUPPORT_UNICODE
       if (utf) switch(Lctype)
         {
+        case OP_ANY_NOTNL:
         case OP_ANY:
         for (i = 1; i <= Lmin; i++)
           {
@@ -2848,6 +2855,8 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if ((Lctype == OP_ANY_NOTNL) && (*Feptr == CHAR_LF))
+            RRETURN(MATCH_NOMATCH);
           if (IS_NEWLINE(Feptr)) RRETURN(MATCH_NOMATCH);
           if (mb->partial != 0 &&
               Feptr + 1 >= mb->end_subject &&
@@ -3093,6 +3102,7 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
 
       switch(Lctype)
         {
+        case OP_ANY_NOTNL:
         case OP_ANY:
         for (i = 1; i <= Lmin; i++)
           {
@@ -3101,6 +3111,8 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if ((Lctype == OP_ANY_NOTNL) && (*Feptr == CHAR_LF))
+            RRETURN(MATCH_NOMATCH);
           if (IS_NEWLINE(Feptr)) RRETURN(MATCH_NOMATCH);
           if (mb->partial != 0 &&
               Feptr + 1 >= mb->end_subject &&
@@ -3610,6 +3622,8 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if ((Lctype == OP_ANY_NOTNL) && (*Feptr == CHAR_LF))
+            RRETURN(MATCH_NOMATCH);
           if (Lctype == OP_ANY && IS_NEWLINE(Feptr)) RRETURN(MATCH_NOMATCH);
           GETCHARINC(fc, Feptr);
           switch(Lctype)
@@ -3737,6 +3751,8 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
             SCHECK_PARTIAL();
             RRETURN(MATCH_NOMATCH);
             }
+          if ((Lctype == OP_ANY_NOTNL) && (*Feptr == CHAR_LF))
+            RRETURN(MATCH_NOMATCH);
           if (Lctype == OP_ANY && IS_NEWLINE(Feptr))
             RRETURN(MATCH_NOMATCH);
           fc = *Feptr++;
@@ -4174,6 +4190,7 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
         {
         switch(Lctype)
           {
+          case OP_ANY_NOTNL:
           case OP_ANY:
           for (i = Lmin; i < Lmax; i++)
             {
@@ -4182,6 +4199,8 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
               SCHECK_PARTIAL();
               break;
               }
+            if ((Lctype == OP_ANY_NOTNL) && (*Feptr == CHAR_LF))
+              RRETURN(MATCH_NOMATCH);
             if (IS_NEWLINE(Feptr)) break;
             if (mb->partial != 0 &&    /* Take care with CRLF partial */
                 Feptr + 1 >= mb->end_subject &&
@@ -4423,6 +4442,7 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
         {
         switch(Lctype)
           {
+          case OP_ANY_NOTNL:
           case OP_ANY:
           for (i = Lmin; i < Lmax; i++)
             {
@@ -4431,6 +4451,8 @@ fprintf(stderr, "++ op=%d\n", *Fecode);
               SCHECK_PARTIAL();
               break;
               }
+            if ((Lctype == OP_ANY_NOTNL) && (*Feptr == CHAR_LF))
+              RRETURN(MATCH_NOMATCH);
             if (IS_NEWLINE(Feptr)) break;
             if (mb->partial != 0 &&    /* Take care with CRLF partial */
                 Feptr + 1 >= mb->end_subject &&

--- a/src/pcre2_study.c
+++ b/src/pcre2_study.c
@@ -358,6 +358,7 @@ for (;;)
     case OP_WORDCHAR:
     case OP_ANY:
     case OP_ALLANY:
+    case OP_ANY_NOTNL:
     case OP_EXTUNI:
     case OP_HSPACE:
     case OP_NOT_HSPACE:
@@ -996,6 +997,7 @@ do
       case OP_ASSERT_ACCEPT:
       case OP_ALLANY:
       case OP_ANY:
+      case OP_ANY_NOTNL:
       case OP_ANYBYTE:
       case OP_CIRCM:
       case OP_CLOSE:
@@ -1392,6 +1394,7 @@ do
         default:
         case OP_ANY:
         case OP_ALLANY:
+        case OP_ANY_NOTNL:
         return SSB_FAIL;
 
         case OP_HSPACE:

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -658,6 +658,7 @@ static modstruct modlist[] = {
   { "dfa_restart",                 MOD_DAT,  MOD_OPT, PCRE2_DFA_RESTART,          DO(options) },
   { "dfa_shortest",                MOD_DAT,  MOD_OPT, PCRE2_DFA_SHORTEST,         DO(options) },
   { "dollar_endonly",              MOD_PAT,  MOD_OPT, PCRE2_DOLLAR_ENDONLY,       PO(options) },
+  { "dot_no_lf",                   MOD_PAT,  MOD_OPT, PCRE2_NO_DOTNL,             PO(options) },
   { "dotall",                      MOD_PATP, MOD_OPT, PCRE2_DOTALL,               PO(options) },
   { "dupnames",                    MOD_PATP, MOD_OPT, PCRE2_DUPNAMES,             PO(options) },
   { "endanchored",                 MOD_PD,   MOD_OPT, PCRE2_ENDANCHORED,          PD(options) },
@@ -4171,7 +4172,7 @@ static void
 show_compile_options(uint32_t options, const char *before, const char *after)
 {
 if (options == 0) fprintf(outfile, "%s <none>%s", before, after);
-else fprintf(outfile, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+else fprintf(outfile, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
   before,
   ((options & PCRE2_ALT_BSUX) != 0)? " alt_bsux" : "",
   ((options & PCRE2_ALT_CIRCUMFLEX) != 0)? " alt_circumflex" : "",
@@ -4181,6 +4182,7 @@ else fprintf(outfile, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%
   ((options & PCRE2_AUTO_CALLOUT) != 0)? " auto_callout" : "",
   ((options & PCRE2_CASELESS) != 0)? " caseless" : "",
   ((options & PCRE2_DOLLAR_ENDONLY) != 0)? " dollar_endonly" : "",
+  ((options & PCRE2_NO_DOTNL) != 0)? " dot_no_lf" : "",
   ((options & PCRE2_DOTALL) != 0)? " dotall" : "",
   ((options & PCRE2_DUPNAMES) != 0)? " dupnames" : "",
   ((options & PCRE2_ENDANCHORED) != 0)? " endanchored" : "",

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -1909,6 +1909,19 @@
     a\rb
     a\x85b
 
+/^a.b/newline=cr,dot_no_lf
+    a\0b
+\= Expect no match
+    a\nb
+    a\rb
+
+/^a.b/newline=nul,dot_no_lf
+    a\rb
+    a\x85b
+\= Expect no match
+    a\nb
+    a\0b
+
 /^abc./gmx,newline=any
     abc1 \x0aabc2 \x0babc3xx \x0cabc4 \x0dabc5xx \x0d\x0aabc6 \x85abc7 JUNK
 
@@ -1999,11 +2012,6 @@
 
 /^(a)\g{aa}/
 
-/^a.b/newline=lf
-    a\rb
-\= Expect no match
-    a\nb
-
 /.+foo/
     afoo
 \= Expect no match
@@ -2022,7 +2030,23 @@
     \nfoo
     \r\nfoo
 
+/.+foo/newline=nul
+    afoo
+    \nfoo
+    \r\nfoo
+
+/.+foo/newline=nul,dot_no_lf
+    afoo
+\= Expect no match
+    \nfoo
+    \r\nfoo
+
 /.+foo/s
+    afoo
+    \r\nfoo
+    \nfoo
+
+/.+foo/s,dot_no_lf
     afoo
     \r\nfoo
     \nfoo

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -7506,6 +7506,26 @@ No match
     a\x85b
 No match
 
+/^a.b/newline=cr,dot_no_lf
+    a\0b
+ 0: a\x00b
+\= Expect no match
+    a\nb
+No match
+    a\rb
+No match
+
+/^a.b/newline=nul,dot_no_lf
+    a\rb
+ 0: a\x0db
+    a\x85b
+ 0: a\x85b
+\= Expect no match
+    a\nb
+No match
+    a\0b
+No match
+
 /^abc./gmx,newline=any
     abc1 \x0aabc2 \x0babc3xx \x0cabc4 \x0dabc5xx \x0d\x0aabc6 \x85abc7 JUNK
  0: abc1
@@ -7679,13 +7699,6 @@ Failed: error 157 at offset 6: \g is not followed by a braced, angle-bracketed, 
 /^(a)\g{aa}/
 Failed: error 115 at offset 7: reference to non-existent subpattern
 
-/^a.b/newline=lf
-    a\rb
- 0: a\x0db
-\= Expect no match
-    a\nb
-No match
-
 /.+foo/
     afoo
  0: afoo
@@ -7713,7 +7726,32 @@ No match
     \r\nfoo
 No match
 
+/.+foo/newline=nul
+    afoo
+ 0: afoo
+    \nfoo
+ 0: \x0afoo
+    \r\nfoo
+ 0: \x0d\x0afoo
+
+/.+foo/newline=nul,dot_no_lf
+    afoo
+ 0: afoo
+\= Expect no match
+    \nfoo
+No match
+    \r\nfoo
+No match
+
 /.+foo/s
+    afoo
+ 0: afoo
+    \r\nfoo
+ 0: \x0d\x0afoo
+    \nfoo
+ 0: \x0afoo
+
+/.+foo/s,dot_no_lf
     afoo
  0: afoo
     \r\nfoo


### PR DESCRIPTION
The first patch could be taken AS-IS, but the rest are only a POC (meant more for design discussion), since they are  probably incomplete, missing tests, documentation and will need serious refactoring.

It also has probably questionable names, and might be missing pieces, as I am not familiar with this part of the codebase and I simply mindlessly did the changes that were needed to compile, but it seems to work fine on my tests, and therefore think could do with some peer review.

Fixes: #43