### PR TITLE
cmake: avoid man3 glob post processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1022,12 +1022,6 @@ FILE(GLOB html ${PROJECT_SOURCE_DIR}/doc/html/*.html)
 FILE(GLOB man1 ${PROJECT_SOURCE_DIR}/doc/*.1)
 FILE(GLOB man3 ${PROJECT_SOURCE_DIR}/doc/*.3)
 
-FOREACH(man ${man3})
-        GET_FILENAME_COMPONENT(man_tmp ${man} NAME)
-        SET(man3_new ${man3} ${man})
-ENDFOREACH(man ${man3})
-SET(man3 ${man3_new})
-
 INSTALL(FILES ${man1} DESTINATION man/man1)
 INSTALL(FILES ${man3} DESTINATION man/man3)
 INSTALL(FILES ${html} DESTINATION share/doc/pcre2/html)


### PR DESCRIPTION
Issue can be replicated, regardless of OS or generator used.

Affected code doesn't seem to be very useful or needed, and has been tested to work with modern MSVC and Xcode 