### PR TITLE
pcre2_string_utils: avoid segfault with strlen(NULL)

### DIFF
--- a/doc/pcre2_substitute.3
+++ b/doc/pcre2_substitute.3
@@ -53,7 +53,7 @@ changed to the length of the new string, excluding the trailing zero that is
 automatically added.
 .P
 The subject and replacement lengths can be given as PCRE2_ZERO_TERMINATED for
-zero-terminated strings. The options are:
+zero-terminated strings. if used with a replacement string of NULL, then it is assumed to be equivalent to the behaviour expected from a replacement string of NULL and a length of 0. The options are:
 .sp
   PCRE2_ANCHORED             Match only at the first position
   PCRE2_ENDANCHORED          Pattern can match only at end of subject

--- a/src/pcre2_string_utils.c
+++ b/src/pcre2_string_utils.c
@@ -209,6 +209,7 @@ PCRE2_SIZE
 PRIV(strlen)(PCRE2_SPTR str)
 {
 PCRE2_SIZE c = 0;
+if (str == NULL) return 0;
 while (*str++ != 0) c++;
 return c;
 }


### PR DESCRIPTION
As the first step towards allowing the use of NULL together with a length of 0 as equivalent to "" for a subject as suggested in #54, but also as an alternative fix for the failures addressed by #53.