### PR TITLE
Fix typo `with-match-limit_depth` -> `with-match-limit-depth`

### DIFF
--- a/doc/html/pcre2build.html
+++ b/doc/html/pcre2build.html
@@ -308,7 +308,7 @@ You can also explicitly limit the depth of nested backtracking in the
 for --with-match-limit. You can set a lower default limit by adding, for
 example,
 <pre>
-  --with-match-limit_depth=10000
+  --with-match-limit-depth=10000
 </pre>
 to the <b>configure</b> command. This value can be overridden at run time. This
 depth limit indirectly limits the amount of heap memory that is used, but

--- a/doc/pcre2.txt
+++ b/doc/pcre2.txt
@@ -4138,7 +4138,7 @@ LIMITING PCRE2 RESOURCE USAGE
        for --with-match-limit. You can set a lower default  limit  by  adding,
        for example,
 
-         --with-match-limit_depth=10000
+         --with-match-limit-depth=10000
 
        to  the  configure  command.  This value can be overridden at run time.
        This depth limit indirectly limits the amount of heap  memory  that  is

--- a/doc/pcre2build.3
+++ b/doc/pcre2build.3
@@ -303,7 +303,7 @@ You can also explicitly limit the depth of nested backtracking in the
 for --with-match-limit. You can set a lower default limit by adding, for
 example,
 .sp
-  --with-match-limit_depth=10000
+  --with-match-limit-depth=10000
 .sp
 to the \fBconfigure\fP command. This value can be overridden at run time. This
 depth limit indirectly limits the amount of heap memory that is used, but


### PR DESCRIPTION
Noticed while reading pcre2.txt. Apologies if this is the wrong way to update docs.