### PR TITLE
Enable fuzzing of the JIT engine

### DIFF
--- a/src/pcre2_fuzzsupport.c
+++ b/src/pcre2_fuzzsupport.c
@@ -148,6 +148,9 @@ for (i = 0; i < 2; i++)
 
   if (code != NULL)
     {
+#ifdef SUPPORT_JIT
+    pcre2_jit_compile(code, PCRE2_JIT_COMPLETE);
+#endif
     int j;
     uint32_t save_match_options = match_options;
 


### PR DESCRIPTION
This PR enables fuzzing of the JIT engine when PCRE2 is compiled with `--enable-fuzz-support --enable-jit`. 
I have tested this patch locally and it found some crashes in the JIT compiler (fixed in 50a51cb7e67268e6ad417eb07c9de9bfea5cc55a and 4ca0530b9bdf00d2485d612ddfab8d21c72dc83a). 